### PR TITLE
feat(ludo): rotate the board from settings, so your colour sits neare…

### DIFF
--- a/AttendanceTimeCheckerPlus.js
+++ b/AttendanceTimeCheckerPlus.js
@@ -331,6 +331,10 @@
         ludoThreeSixes: true,   // three 6s forfeit the whole banked sequence
         ludoExactHome: true,    // exact roll needed to finish
         ludoFreeRelease: false, // leave base on any roll, not just a 6
+        // 0-3 counter-clockwise quarter-turns of the board, so a player can put
+        // their own colour nearest them. Purely presentational — see the board
+        // rotation notes in the LUDO block.
+        ludoRotation: 0,
         // Cyberpunk HUD customizable colors (only applied when displayTheme === 'retro-futuristic')
         cyberBgPrimary: '#07091a',
         cyberBgSecondary: '#11142b',
@@ -6990,19 +6994,63 @@
     // Concatenated after ludo-core.js. Everything here is canvas-drawn: the ⛶ Max
     // modal relocates only the <canvas>, so a DOM-based HUD would vanish inside it.
     //
-    // Layout — 368 × 404:
-    //   0–52     top strip     Blue chip (left) · Red chip (right)
-    //   52–352   board         300 × 300, inset 34px each side, wooden frame
-    //   352–404  bottom strip  Yellow chip (left) · Green chip (right)
-    // The dice renders in whichever strip belongs to the player to move, so the
-    // eye is drawn to the right half of the board — same idea as Ludo Star.
+    // Layout — 344 × 416:
+    //   0–58     top strip     two player chips, dice between them
+    //   58–358   board         300 × 300, inset 22px each side, wooden frame
+    //   358–416  bottom strip  the other two chips
+    // Each chip sits in the strip on its own quadrant's side, and the dice
+    // renders in whichever strip belongs to the player to move, so the eye is
+    // drawn to the right half of the board — same idea as Ludo Star. Which
+    // quadrant is where depends on the board rotation; see ludoSeat below.
 
-    const LUDO_SEATS = {
-        0: { strip: 'top',    side: 'left'  },   // blue   — top-left quadrant
-        1: { strip: 'top',    side: 'right' },   // red    — top-right
-        2: { strip: 'bottom', side: 'right' },   // green  — bottom-right
-        3: { strip: 'bottom', side: 'left'  },   // yellow — bottom-left
-    };
+    // ── Board rotation ─────────────────────────────────────────────────
+    // Players want their own colour nearest them, so the board can be turned in
+    // quarter-turns. Two rules keep this from breaking anything:
+    //
+    //   1. Rotate COORDINATES, never the model. ludoStepToCell, the ring indices
+    //      and every rule still speak unrotated grid space, so a turn cannot
+    //      change what is legal — only where it is painted. Everything funnels
+    //      through ludoPointXY, so board, tokens, ghosts, the hop animation and
+    //      hit-testing all follow from that one function.
+    //   2. Never rotate the canvas context. ctx.rotate would carry the dice
+    //      pips, chip labels and stack badges over with it and leave them
+    //      upside down; only positions should move, not glyphs.
+    //
+    // 0..3 counter-clockwise quarter-turns, so Blue's quadrant walks
+    // top-left → bottom-left → bottom-right → top-right.
+    function ludoRotation() {
+        const P = (typeof userPreferences === 'object' && userPreferences) ? userPreferences : {};
+        const raw = P.ludoRotation;
+        const n = typeof raw === 'number' ? raw : parseInt(raw, 10);
+        return Number.isFinite(n) ? ((n % 4) + 4) % 4 : 0;
+    }
+
+    // (gr, gc) are grid-LINE coordinates in [0, LUDO_GRID] rather than cell
+    // indices, so this serves cell corners, cell centres (x.5), base slots and
+    // the board centre alike. The centre (7.5, 7.5) is a fixed point.
+    function ludoRotateGrid(gr, gc) {
+        const G = LUDO_GRID;
+        switch (ludoRotation()) {
+            case 1:  return { r: G - gc, c: gr };        // 90° CCW
+            case 2:  return { r: G - gr, c: G - gc };    // 180°
+            case 3:  return { r: gc,     c: G - gr };    // 90° CW
+            default: return { r: gr,     c: gc };
+        }
+    }
+
+    // Which HUD strip a colour's chip belongs in, derived from where its
+    // quadrant actually ended up rather than a fixed table — so the chips, the
+    // dice and the roll recap all follow the board round. A quarter-turn is a
+    // bijection on quadrants, so the four seats always land in four distinct
+    // (strip, side) slots and can never collide.
+    function ludoSeat(ci) {
+        const q = LUDO_COLORS[ci].quad;
+        const p = ludoRotateGrid((q.r0 + q.r1) / 2, (q.c0 + q.c1) / 2);
+        return {
+            strip: p.r < LUDO_GRID / 2 ? 'top'  : 'bottom',
+            side:  p.c < LUDO_GRID / 2 ? 'left' : 'right',
+        };
+    }
 
     // ── Interaction state ──────────────────────────────────────────────
     let ludoPhase      = 'idle';   // idle | awaitRoll | rolling | awaitMove | moving | over
@@ -7032,10 +7080,22 @@
     // ludoPointXY takes grid-line coords (base slots, triangle vertices);
     // ludoCellCenter takes a cell index and returns the middle of that cell.
     function ludoPointXY(r, c) {
-        return { x: LUDO_BOARD_X + c * LUDO_CELL, y: LUDO_BOARD_Y + r * LUDO_CELL };
+        const p = ludoRotateGrid(r, c);
+        return { x: LUDO_BOARD_X + p.c * LUDO_CELL, y: LUDO_BOARD_Y + p.r * LUDO_CELL };
     }
     function ludoCellCenter(r, c) {
         return ludoPointXY(r + 0.5, c + 0.5);
+    }
+
+    // Axis-aligned rect spanning grid lines [r0,r1] × [c0,c1]. A quarter-turn
+    // keeps a rect axis-aligned but moves which corner is which, so derive it
+    // from both rotated corners instead of assuming (r0,c0) is still top-left.
+    function ludoRectXY(r0, c0, r1, c1) {
+        const a = ludoPointXY(r0, c0), b = ludoPointXY(r1, c1);
+        return {
+            x: Math.min(a.x, b.x), y: Math.min(a.y, b.y),
+            w: Math.abs(b.x - a.x), h: Math.abs(b.y - a.y),
+        };
     }
 
     // Where token `i` of colour `ci` sits at an arbitrary step, including the
@@ -7150,13 +7210,13 @@
     }
 
     function ludoDrawCell(ctx, r, c, fill, stroke) {
-        const p = ludoPointXY(r, c);
+        const q = ludoRectXY(r, c, r + 1, c + 1);
         ctx.fillStyle = fill;
-        ctx.fillRect(p.x, p.y, LUDO_CELL, LUDO_CELL);
+        ctx.fillRect(q.x, q.y, q.w, q.h);
         if (stroke) {
             ctx.strokeStyle = stroke;
             ctx.lineWidth = 1;
-            ctx.strokeRect(p.x + 0.5, p.y + 0.5, LUDO_CELL - 1, LUDO_CELL - 1);
+            ctx.strokeRect(q.x + 0.5, q.y + 0.5, q.w - 1, q.h - 1);
         }
     }
 
@@ -7180,13 +7240,17 @@
         const col  = LUDO_COLORS[ci];
         const cur  = LUDO_RING[col.startIndex];
         const next = LUDO_RING[(col.startIndex + 1) % 52];
-        const dr = Math.sign(next.r - cur.r), dc = Math.sign(next.c - cur.c);
+        // Take the heading from the two squares' *drawn* positions, so the arrow
+        // turns with the board instead of always pointing the unrotated way.
+        // No start square sits on one of the four diagonal corner turns, so this
+        // is always exactly horizontal or vertical.
         const p  = ludoCellCenter(cur.r, cur.c);
+        const n  = ludoCellCenter(next.r, next.c);
         const L  = LUDO_CELL * 0.30;
 
         ctx.save();
         ctx.translate(p.x, p.y);
-        ctx.rotate(Math.atan2(dr, dc));
+        ctx.rotate(Math.atan2(n.y - p.y, n.x - p.x));
         ctx.beginPath();
         ctx.moveTo(L, 0);
         ctx.lineTo(-L * 0.65, -L * 0.8);
@@ -7211,19 +7275,18 @@
             const tint = on ? col.hex : ludoDim(col.hex);
             const deep = on ? col.deep : ludoDim(col.deep);
             const q = col.quad, b = col.basePanel;
-            const qp = ludoPointXY(q.r0, q.c0);
+            const qr = ludoRectXY(q.r0, q.c0, q.r1, q.c1);
 
             ctx.fillStyle = tint;
-            ctx.fillRect(qp.x, qp.y, (q.c1 - q.c0) * S, (q.r1 - q.r0) * S);
+            ctx.fillRect(qr.x, qr.y, qr.w, qr.h);
 
-            const bp = ludoPointXY(b.r0, b.c0);
-            const bw = (b.c1 - b.c0) * S, bh = (b.r1 - b.r0) * S;
+            const br = ludoRectXY(b.r0, b.c0, b.r1, b.c1);
             ctx.fillStyle = '#fbfcfe';
-            ludoRoundRect(ctx, bp.x, bp.y, bw, bh, 8);
+            ludoRoundRect(ctx, br.x, br.y, br.w, br.h, 8);
             ctx.fill();
             ctx.strokeStyle = deep;
             ctx.lineWidth = 2;
-            ludoRoundRect(ctx, bp.x + 1, bp.y + 1, bw - 2, bh - 2, 7);
+            ludoRoundRect(ctx, br.x + 1, br.y + 1, br.w - 2, br.h - 2, 7);
             ctx.stroke();
 
             col.baseSlots.forEach(s => {
@@ -7277,7 +7340,8 @@
         });
         ctx.strokeStyle = 'rgba(40,50,70,0.35)';
         ctx.lineWidth = 1.5;
-        ctx.strokeRect(ludoPointXY(6, 6).x, ludoPointXY(6, 6).y, S * 3, S * 3);
+        const cr = ludoRectXY(6, 6, 9, 9);
+        ctx.strokeRect(cr.x, cr.y, cr.w, cr.h);
 
         if (ludoDebugRing) {
             ctx.font = '8px monospace';
@@ -7676,7 +7740,7 @@
     function ludoDrawPool(ctx, strip) {
         if (!ludoStarted || ludoPhase === 'over' || !ludoPool.length) return;
         const cur  = ludoCurrentCi();
-        const seat = LUDO_SEATS[cur];
+        const seat = ludoSeat(cur);
         if (seat.strip !== strip) return;
 
         const D = 15, GAP = 2;
@@ -7695,7 +7759,7 @@
     // the moment the next roll starts (see ludoDoRoll).
     function ludoDrawRecap(ctx, strip) {
         if (!ludoRecap || !ludoRecap.faces.length) return;
-        const seat = LUDO_SEATS[ludoRecap.ci];
+        const seat = ludoSeat(ludoRecap.ci);
         if (seat.strip !== strip || !ludoIsActive(ludoRecap.ci)) return;
 
         // At most 4, most recent first-to-last. Three sixes is the natural
@@ -7715,12 +7779,12 @@
 
     function ludoDrawHud(ctx) {
         const cur = ludoCurrentCi();
-        const curStrip = ludoPhase === 'over' ? null : LUDO_SEATS[cur].strip;
+        const curStrip = ludoPhase === 'over' ? null : ludoSeat(cur).strip;
 
         ['top', 'bottom'].forEach(strip => {
             const y0 = strip === 'top' ? 0 : LUDO_CANVAS_H - LUDO_STRIP_H;
             ludoActive.forEach(ci => {
-                const seat = LUDO_SEATS[ci];
+                const seat = ludoSeat(ci);
                 if (seat.strip !== strip) return;
                 ludoDrawChip(ctx, ci, ludoChipX(seat.side),
                              y0 + (LUDO_STRIP_H - LUDO_CHIP_H) / 2,
@@ -8035,7 +8099,7 @@
 
     function ludoDiceHit(p) {
         if (ludoPhase === 'over') return false;
-        const seat = LUDO_SEATS[ludoCurrentCi()];
+        const seat = ludoSeat(ludoCurrentCi());
         const cy = seat.strip === 'top'
             ? LUDO_STRIP_H / 2
             : LUDO_CANVAS_H - LUDO_STRIP_H / 2;
@@ -14541,6 +14605,15 @@
                     <div class="pool-color-swatch ${userPreferences.poolTableColor === 'lightgrey' ? 'active' : ''}" data-pool-color="lightgrey" style="background: linear-gradient(135deg, #a8b0b8, #c8cfd6);" title="Light Grey"></div>
                 </div>
             </div>
+            <div class="settings-option">
+                <span class="settings-option-label">🎲 Ludo Board</span>
+                <select class="settings-select" data-pref="ludoRotation">
+                    <option value="0" ${Number(userPreferences.ludoRotation) === 0 ? 'selected' : ''}>Blue top-left (default)</option>
+                    <option value="1" ${Number(userPreferences.ludoRotation) === 1 ? 'selected' : ''}>Blue bottom-left</option>
+                    <option value="2" ${Number(userPreferences.ludoRotation) === 2 ? 'selected' : ''}>Blue bottom-right</option>
+                    <option value="3" ${Number(userPreferences.ludoRotation) === 3 ? 'selected' : ''}>Blue top-right</option>
+                </select>
+            </div>
             <div class="settings-option" style="align-items: flex-start; flex-direction: column; gap: 10px;">
                 <span class="settings-option-label">🎲 Ludo Rules</span>
                 <div class="ludo-rule-toggles">
@@ -14587,7 +14660,10 @@
         modal.querySelectorAll('.settings-select').forEach(select => {
             select.addEventListener('change', function() {
                 const pref = this.getAttribute('data-pref');
-                userPreferences[pref] = pref === 'gameFps' ? parseInt(this.value) : this.value;
+                // Selects hand back strings; these two are numbers everywhere else.
+                const numericPrefs = ['gameFps', 'ludoRotation'];
+                userPreferences[pref] = numericPrefs.indexOf(pref) !== -1
+                    ? parseInt(this.value, 10) : this.value;
                 savePreferences();
                 applyPreferences();
                 

--- a/LUDO_IMPLEMENTATION_PLAN.md
+++ b/LUDO_IMPLEMENTATION_PLAN.md
@@ -8,7 +8,7 @@
 > Branch: `feat/ludo-game` (off `main` @ `efbf33d`)
 > Status: **Phases 0–11 complete — Ludo is integrated.** The engine lives in
 > `AttendanceTimeCheckerPlus.js` (now 16,491 lines), byte-identical to the copy in
-> [`ludo-dev/`](ludo-dev/) that the tests exercise. **508 assertions green**, including
+> [`ludo-dev/`](ludo-dev/) that the tests exercise. **584 assertions green**, including
 > a suite that executes the real userscript. The only step left is a pass on the live
 > portal — see Verification.
 > Last updated: 2026-08-05
@@ -166,6 +166,33 @@ because the Max modal relocates only the `<canvas>`.
 Seats map to quadrants — Blue TL, Red TR, Green BR, Yellow BL — and each player's chip
 sits in the strip on their own side of the board. The dice renders in whichever strip
 belongs to the player to move, so attention follows the turn.
+
+### Board rotation
+
+⚙️ **🎲 Ludo Board** turns the board in quarter-turns so a player can put their own
+colour nearest them — `userPreferences.ludoRotation`, 0–3 counter-clockwise turns,
+labelled by where Blue lands (top-left → bottom-left → bottom-right → top-right).
+
+Two rules make this safe, and both are asserted:
+
+1. **Rotate coordinates, not the model.** `ludoStepToCell`, the ring indices and every
+   rule still speak unrotated grid space, so a turn *cannot* change what is legal.
+   Everything funnels through `ludoPointXY`, so the board, tokens, ghosts, the hop
+   animation and hit-testing all follow from one function. `rotation-verify.js` pins
+   this by comparing legal-move sets and step→cell output across all four turns.
+2. **Never rotate the canvas context.** `ctx.rotate` would carry the dice pips, chip
+   labels and stack badges with it and leave them upside down. Only positions move.
+
+Two things that are *not* automatic and had to be handled explicitly:
+
+- `ludoDrawCell` and the quadrant/base rects assumed `(r0,c0)` was the top-left corner.
+  A quarter-turn keeps a rect axis-aligned but moves which corner is which, so
+  `ludoRectXY` derives it from both rotated corners.
+- The HUD is in strip space, not board space. `ludoSeat(ci)` derives a colour's
+  strip/side from its quadrant's *rotated* centre, so chips, the dice and the roll
+  recap follow the board round. A quarter-turn is a bijection on quadrants, so the four
+  seats always land in four distinct slots — asserted, since a collision would stack
+  two chips.
 
 ```
 LUDO_RING      52 × {r,c}, clockwise         // shared track
@@ -529,7 +556,7 @@ The script self-guards to one URL (43–48), so iterating in-place is slow.
 own [README](ludo-dev/README.md). One command:
 
 ```
-node ludo-dev/verify-all.js     # 508 assertions across 8 suites, non-zero exit on failure
+node ludo-dev/verify-all.js     # 584 assertions across 9 suites, non-zero exit on failure
 ```
 
 | Suite | Covers | Assertions |
@@ -539,6 +566,7 @@ node ludo-dev/verify-all.js     # 508 assertions across 8 suites, non-zero exit 
 | `ai-verify.js` | Tiers, scorer, 600-game strength ordering | 36 |
 | `modes-verify.js` | Mode cycling, seats, turn order | 38 |
 | `ui-verify.js` | State machine, animation, clock, pointer input, die-choice popover, recap, anti-farm, XP | 126 |
+| `rotation-verify.js` | Board rotation — that it moves quadrants, chips, dice and hit-testing, and moves nothing else | 76 |
 | `render-smoke.js` | `ludoRender()` across all modes and steps | 10 |
 | `integration-verify.js` | Every wiring point in `AttendanceTimeCheckerPlus.js`, plus engine parity | 51 |
 | `host-smoke.js` | **Executes the real userscript**: full PvCPU match, XP, achievements, cloud round-trip, both Max modals | 55 |
@@ -611,6 +639,10 @@ doesn't re-derive it from the code.
 | **2026-08-04** | **Extra turns now come only from a capture or a token reaching home** | Otherwise a 6 would pay twice — once as an extra die and again as an extra turn. `ludoGrantsExtraTurn(roll, result)` became `ludoEarnsAnotherRoll(result)`; `ludoFinishMove` lost its `roll` argument and returns `{ continueTurn, extraRoll }`. |
 | **2026-08-04** | **Tap a token → popover of that token's playable values** | With up to three distinct values banked, a tap is ambiguous. `ludoValuesForToken` filters the pool to what that token can legally spend: one value moves immediately, several open a popover anchored to the token. `ludoPopoverLayout()` is shared by the renderer and the hit-test so they cannot drift. |
 | **2026-08-04** | **Ghost previews suppressed while several distinct values are banked** | Three values × four tokens is up to a dozen ghost destinations. Ghosts now show only when one distinct value remains, or when a popover has narrowed it to one token; otherwise the glow and chevron carry it. |
+| **2026-08-05** | **Board rotation is a coordinate transform, not a canvas transform** | *Requested by the user — players want their own colour nearest them.* `ctx.rotate` would have been one line, but it turns the dice pips, chip labels and stack badges upside down with the board. Instead `ludoRotateGrid` maps grid-line coordinates and everything funnels through `ludoPointXY`, so glyphs stay upright while positions move. The model is untouched, which is what makes it safe to change mid-match. |
+| **2026-08-05** | **`ludoSeat(ci)` replaced the static `LUDO_SEATS` table** | The HUD lives in strip space, not board space, so it does not rotate for free. Deriving each colour's strip/side from its quadrant's rotated centre means the chips, dice and roll recap follow the board without a second lookup table to keep in sync. |
+| **2026-08-05** | **`ludoRectXY` for anything rectangular** | `fillRect(ludoPointXY(r0,c0), w, h)` assumed `(r0,c0)` stays the top-left corner. Under a quarter-turn it becomes a different corner, which drew quadrants and base panels one cell off. Deriving the rect from both rotated corners is rotation-agnostic. |
+| **2026-08-05** | **Match-completion loops now drive the moves instead of waiting on the turn clock** | `host-smoke.js` and `rotation-verify.js` played a hot-seat match by letting the 20s clock time each turn out. That converges far too slowly to bound with an iteration guard and made the suite intermittently fail. Both now roll and play directly; the suite is stable over repeated runs. |
 | **2026-08-05** | **Ludo's localStorage helpers stayed in the engine block, not beside `savePoolRecord`** | The plan put `load/saveLudoWins` and `load/saveLudoRecord` at ~557. They were already written and covered by the headless XP tests inside `ludo-ui.js`, and moving them would have split the tested source from the integrated source. Parity between the two is now an asserted invariant (`integration-verify.js` compares the bytes), which is worth more than the placement. A pointer comment sits at 557 for anyone looking there. |
 | **2026-08-05** | **The XP formula stayed in `endLudoGame`; `awardGameXP`'s case only clamps and phrases it** | The plan put the arithmetic in `awardGameXP`. It was already implemented and pinned by tests in `endLudoGame`, which is also where the CPU-vs-hot-seat and win/placement facts live. `awardGameXP` re-clamps to `AC_MAX_XP_PER_GAME` because that is the host's contract with the sync anti-cheat and is the last point before the XP lands. |
 | **2026-08-05** | **`toggleGameMaxModal` keys its state by `canvasId` instead of taking a `stateRef`** | The plan suggested passing a state reference. A module-level map keyed by canvas id means neither game can corrupt the other's state, and callers just store the returned boolean — `poolMaximized` and `ludoMaximized` keep working exactly as before. |

--- a/ludo-dev/README.md
+++ b/ludo-dev/README.md
@@ -8,7 +8,7 @@ is slow. The engine is built and tested here first, then inserted into that file
 reviewed diff.
 
 ```
-node ludo-dev/verify-all.js              # every suite — 508 assertions
+node ludo-dev/verify-all.js              # every suite — 584 assertions
 node ludo-dev/preview.js out.png fourplayer   # render a PNG of the board
 start ludo-dev/ludo-harness.html         # play it
 ```
@@ -30,7 +30,7 @@ modal relocates only the `<canvas>`, so a DOM HUD would disappear inside it.
 | `load.js` | Evaluates core + UI in a `Function` wrapper and exposes their internals plus test helpers (`place`, `tok`, `forceDice`). Neither source file has exports of its own — this is what makes the same code both drop-in-able and testable. |
 | `canvas-stub.js` | Recording stand-in for `CanvasRenderingContext2D`; returns usable objects from `createLinearGradient` and `measureText` so draw code runs to completion. |
 | `verify-all.js` | Runs every suite and prints one summary. Non-zero exit if any fails. |
-| `preview.js` | Software rasterizer — renders the real `ludoRender()` output to a PNG with no native dependencies, so layout can be inspected without a browser. Scenarios: `fresh`, `midgame`, `fourplayer`, `gameover`, `rolling`, `recap`, `recap4p`, `pool`. |
+| `preview.js` | Software rasterizer — renders the real `ludoRender()` output to a PNG with no native dependencies, so layout can be inspected without a browser. Scenarios: `fresh`, `midgame`, `fourplayer`, `gameover`, `rolling`, `recap`, `recap4p`, `pool`, `rot0`–`rot3`. |
 | `ludo-harness.html` | The playable harness. Mimics the widget's ~330px game column, with mode/play/reset controls, live rule toggles, a state readout, ring-index overlay, a 0→56 token walk, a dice histogram and CPU-vs-CPU auto-play. |
 
 ### Suites
@@ -42,6 +42,7 @@ modal relocates only the `<canvas>`, so a DOM HUD would disappear inside it.
 | `ai-verify.js` | Difficulty tiers, scorer priorities, threat awareness, 600-game head-to-head strength ordering | 36 |
 | `modes-verify.js` | Mode cycling, active colour sets, turn order, CPU seats, reset-on-switch | 38 |
 | `ui-verify.js` | Turn state machine, dice tumble, hop animation, turn clock, scale-aware pointer input, die-choice popover, roll recap, anti-farm guards, XP maths | 126 |
+| `rotation-verify.js` | Board rotation: quadrants land where the setting promises, seats never collide, all 225 cells stay distinct and on-board, legal moves and ring indices are identical at every turn, hit-testing follows | 76 |
 | `render-smoke.js` | `ludoRender()` across every mode and all 57 steps × 4 colours | 10 |
 | `integration-verify.js` | Every wiring point in `AttendanceTimeCheckerPlus.js` — switcher cases, DOM ids, CSS, keyboard, bridges, XP, achievements, leaderboard columns — plus engine parity | 51 |
 | `host-smoke.js` | **Executes the real userscript** under a minimal DOM: boots Ludo, plays a full PvCPU match, checks XP/achievements/cloud round-trip and both Max modals | 55 |

--- a/ludo-dev/host-smoke.js
+++ b/ludo-dev/host-smoke.js
@@ -163,8 +163,8 @@ const EXPORTS = `
     return {
         initLudoGame, startLudoGame, resetLudoGame, cleanupLudoGame,
         cycleLudoModeAndReset, endLudoGame, updateLudoScoreboard,
-        ludoUpdate, ludoRender, ludoSetMode, ludoRollDice,
-        ludoBlockRings, ludoLegalMoves, ludoStepToRing,
+        ludoUpdate, ludoRender, ludoSetMode, ludoRollDice, ludoDoRoll, ludoPlayMove,
+        ludoBlockRings, ludoLegalMoves, ludoStepToRing, ludoSeat, ludoResetTokens,
         toggleGameMaxModal, awardGameXP, checkGameAchievements,
         revalidateAchievements, collectGameBests, buildPlayerSnapshot,
         applyPlayerRecordToLocal, ACHIEVEMENTS, ACHIEVEMENT_XP,
@@ -172,6 +172,7 @@ const EXPORTS = `
         get userXP() { return userXP; },
         get prefs() { return userPreferences; },
         get phase() { return ludoPhase; },
+        get legal() { return ludoLegal; },
         get pool() { return ludoPool; },
         get tokens() { return ludoTokens; },
         get active() { return ludoActive; },
@@ -226,9 +227,15 @@ ok('mode label populated', elements['ludo-mode-label'].textContent === 'PvCPU');
 H.startLudoGame();
 ok('play starts a turn', H.phase === 'awaitRoll');
 
-// Drive a whole PvCPU match on the simulated clock.
+// Drive a whole PvCPU match on the simulated clock. The human seat is played
+// here rather than left to time out on the 20s turn clock — waiting for the
+// clock converges far too slowly to bound with an iteration guard.
 let guard = 0;
-while (H.phase !== 'over' && guard++ < 400000) H.ludoUpdate(16);
+while (H.phase !== 'over' && guard++ < 200000) {
+    H.ludoUpdate(16);
+    if (H.phase === 'awaitRoll') H.ludoDoRoll();
+    else if (H.phase === 'awaitMove' && H.legal.length) H.ludoPlayMove(H.legal[0]);
+}
 ok('a full PvCPU match completes through the host', H.phase === 'over', 'guard=' + guard);
 ok('someone brought all four home', H.active.some(ci =>
     H.tokens.filter(t => t.ci === ci && t.home).length === 4));
@@ -366,6 +373,48 @@ head('Shared Max modal — Ludo');
     ok('buffer restored to 344x416', c.width === 344 && c.height === 416,
        c.width + 'x' + c.height);
     ok('canvas returned to the panel', c.parentNode === homeParent);
+}
+
+head('Board rotation, through the host');
+{
+    // The setting is labelled by where Blue ends up, so check that against the
+    // host's own pref object and its own seat function.
+    const want = ['top-left', 'bottom-left', 'bottom-right', 'top-right'];
+    H.ludoSetMode('cpu2');
+    [0, 1, 2, 3].forEach(r => {
+        H.prefs.ludoRotation = r;
+        const s = H.ludoSeat(0);
+        ok(`rotation ${r}: Blue sits ${want[r]}`,
+           s.strip + '-' + s.side === want[r], `got ${s.strip}-${s.side}`);
+    });
+
+    // Legality must be identical at every rotation — this is the whole safety
+    // claim, re-checked against the integrated copy rather than only ludo-dev/.
+    H.prefs.ludoRotation = 0;
+    H.ludoResetTokens();
+    H.place(0, 0, 12); H.place(2, 0, 30);
+    const baseline = [1, 2, 3, 4, 5, 6]
+        .map(r => H.ludoLegalMoves(0, r).map(m => m.token.i + '>' + m.to).join(',')).join('|');
+    let same = true;
+    [1, 2, 3].forEach(r => {
+        H.prefs.ludoRotation = r;
+        const got = [1, 2, 3, 4, 5, 6]
+            .map(x => H.ludoLegalMoves(0, x).map(m => m.token.i + '>' + m.to).join(',')).join('|');
+        if (got !== baseline) same = false;
+    });
+    ok('legal moves are identical at every rotation', same);
+
+    let threw = null;
+    [0, 1, 2, 3].forEach(r => {
+        H.prefs.ludoRotation = r;
+        try { H.ludoRender(); } catch (e) { threw = 'rot ' + r + ': ' + e.message; }
+    });
+    ok('the board renders at every rotation', threw === null, threw);
+
+    H.prefs.ludoRotation = 'nonsense';
+    ok('a corrupt rotation pref falls back to 0 rather than throwing',
+       (H.ludoRender(), H.ludoSeat(0).strip + '-' + H.ludoSeat(0).side) === 'top-left');
+    H.prefs.ludoRotation = 0;
 }
 
 head('The reported bug, through the host');

--- a/ludo-dev/integration-verify.js
+++ b/ludo-dev/integration-verify.js
@@ -95,6 +95,31 @@ ok('settings modal exposes all four',
 ok('storage helpers live in the engine block',
    has('function ludoLoadWins()') && has('function ludoSaveRecord(rec)'));
 
+head('Board rotation');
+ok('ludoRotation default in userPreferences', has('ludoRotation: 0'));
+ok('rotation select in the settings modal', has('data-pref="ludoRotation"'));
+ok('all four orientations offered',
+   (src.match(/<option value="[0-3]"[^>]*>Blue /g) || []).length === 4);
+ok('the select is stored as a number, not a string',
+   /numericPrefs = \['gameFps', 'ludoRotation'\]/.test(src));
+ok('coordinates rotate, not the model',
+   has('function ludoRotateGrid(gr, gc)') && has('function ludoPointXY(r, c)') &&
+   /ludoPointXY[\s\S]{0,120}?ludoRotateGrid\(r, c\)/.test(src));
+ok('rects derive from both rotated corners', has('function ludoRectXY(r0, c0, r1, c1)'));
+ok('HUD seats derived, not tabled',
+   has('function ludoSeat(ci)') && !has('const LUDO_SEATS'));
+// Board rotation must never reach the canvas transform — ctx.rotate would carry
+// dice pips, chip labels and stack badges over and leave them upside down. The
+// ctx.rotate calls that do exist (Pool's rolling stripe, Ludo's start arrow, the
+// dice tumble wobble) each spin one small shape and know nothing about the
+// board's orientation, so assert that rather than counting call sites.
+const rotateDrivenByBoard = src.split('\n')
+    .filter(l => l.indexOf('ctx.rotate(') !== -1 && /ludoRotat/.test(l));
+ok('no ctx.rotate is driven by the board rotation',
+   rotateDrivenByBoard.length === 0, rotateDrivenByBoard.join(' | '));
+ok('ludoRender sets an unrotated scale transform',
+   /setTransform\(s, 0, 0, s, 0, 0\)/.test(src));
+
 head('XP and achievements');
 ok('awardGameXP has a ludo case', /case 'ludo': \{[\s\S]{0,700}?performance\.xp/.test(src));
 ok('award clamped to AC_MAX_XP_PER_GAME',

--- a/ludo-dev/load.js
+++ b/ludo-dev/load.js
@@ -32,7 +32,7 @@ module.exports = function load(prefs) {
     return new Function(source() + `
         return {
             LUDO_RING, LUDO_COLORS, LUDO_SAFE_RING, LUDO_HOME_STEP, LUDO_START_OWNER,
-            LUDO_MODES, LUDO_MODE_COLORS, LUDO_MODE_LABEL, LUDO_HUMAN_CI, LUDO_SEATS,
+            LUDO_MODES, LUDO_MODE_COLORS, LUDO_MODE_LABEL, LUDO_HUMAN_CI,
             LUDO_CANVAS_W, LUDO_CANVAS_H, LUDO_STRIP_H, LUDO_BOARD, LUDO_BOARD_X,
             LUDO_BOARD_Y, LUDO_CELL, LUDO_TURN_CLOCK, LUDO_DICE_MS, LUDO_HOP_MS,
             LUDO_AUTOPLAY_MS, LUDO_PASS_MS, LUDO_CPU_THINK_MS,
@@ -47,6 +47,7 @@ module.exports = function load(prefs) {
             ludoSetMode, cycleLudoMode, ludoIsCPUSeat,
 
             ludoPointXY, ludoCellCenter, ludoPosForStep, ludoTokenXY, ludoComputeLayout,
+            ludoRotation, ludoRotateGrid, ludoSeat, ludoRectXY,
             ludoRender, ludoDrawBoard, ludoDrawTokens, ludoDrawHud, ludoUpdate,
             ludoBeginTurn, ludoDoRoll, ludoSettleRoll, ludoPlayMove, ludoTimeout,
             ludoAwaitMove, ludoPopoverLayout, ludoDrawPopover,

--- a/ludo-dev/ludo-harness.html
+++ b/ludo-dev/ludo-harness.html
@@ -71,6 +71,16 @@
     <label class="chk"><input type="checkbox" id="p-exact" checked> Exact roll required to finish</label>
     <label class="chk"><input type="checkbox" id="p-free"> Release on any roll (no 6 needed)</label>
   </div>
+
+  <div class="panel">
+    <h1>Board rotation</h1>
+    <div class="tools">
+      <button data-rot="0">Blue ↖ TL</button>
+      <button data-rot="1">Blue ↙ BL</button>
+      <button data-rot="2">Blue ↘ BR</button>
+      <button data-rot="3">Blue ↗ TR</button>
+    </div>
+  </div>
 </div>
 
 <div class="side">
@@ -112,6 +122,7 @@ function awardGameXP(type, perf) {
 }
 let userPreferences = {
     ludoBlocks: true, ludoThreeSixes: true, ludoExactHome: true, ludoFreeRelease: false,
+    ludoRotation: 0,
 };
 const logEl = () => document.getElementById('log');
 function log(msg) {
@@ -152,6 +163,17 @@ $('btn-ring').onclick = function () {
     ludoDebugRing = !ludoDebugRing;
     this.classList.toggle('on', ludoDebugRing);
 };
+
+// Rotation is a pure display pref — safe to change mid-match, the loop redraws.
+document.querySelectorAll('[data-rot]').forEach(b => {
+    b.onclick = () => {
+        userPreferences.ludoRotation = parseInt(b.dataset.rot, 10);
+        document.querySelectorAll('[data-rot]').forEach(o =>
+            o.classList.toggle('on', o === b));
+        log('rotation → ' + b.dataset.rot + ' (' + b.textContent.trim() + ')');
+    };
+});
+document.querySelector('[data-rot="0"]').classList.add('on');
 
 $('btn-scatter').onclick = () => {
     resetLudoGame();

--- a/ludo-dev/ludo-ui.js
+++ b/ludo-dev/ludo-ui.js
@@ -4,19 +4,63 @@
     // Concatenated after ludo-core.js. Everything here is canvas-drawn: the ⛶ Max
     // modal relocates only the <canvas>, so a DOM-based HUD would vanish inside it.
     //
-    // Layout — 368 × 404:
-    //   0–52     top strip     Blue chip (left) · Red chip (right)
-    //   52–352   board         300 × 300, inset 34px each side, wooden frame
-    //   352–404  bottom strip  Yellow chip (left) · Green chip (right)
-    // The dice renders in whichever strip belongs to the player to move, so the
-    // eye is drawn to the right half of the board — same idea as Ludo Star.
+    // Layout — 344 × 416:
+    //   0–58     top strip     two player chips, dice between them
+    //   58–358   board         300 × 300, inset 22px each side, wooden frame
+    //   358–416  bottom strip  the other two chips
+    // Each chip sits in the strip on its own quadrant's side, and the dice
+    // renders in whichever strip belongs to the player to move, so the eye is
+    // drawn to the right half of the board — same idea as Ludo Star. Which
+    // quadrant is where depends on the board rotation; see ludoSeat below.
 
-    const LUDO_SEATS = {
-        0: { strip: 'top',    side: 'left'  },   // blue   — top-left quadrant
-        1: { strip: 'top',    side: 'right' },   // red    — top-right
-        2: { strip: 'bottom', side: 'right' },   // green  — bottom-right
-        3: { strip: 'bottom', side: 'left'  },   // yellow — bottom-left
-    };
+    // ── Board rotation ─────────────────────────────────────────────────
+    // Players want their own colour nearest them, so the board can be turned in
+    // quarter-turns. Two rules keep this from breaking anything:
+    //
+    //   1. Rotate COORDINATES, never the model. ludoStepToCell, the ring indices
+    //      and every rule still speak unrotated grid space, so a turn cannot
+    //      change what is legal — only where it is painted. Everything funnels
+    //      through ludoPointXY, so board, tokens, ghosts, the hop animation and
+    //      hit-testing all follow from that one function.
+    //   2. Never rotate the canvas context. ctx.rotate would carry the dice
+    //      pips, chip labels and stack badges over with it and leave them
+    //      upside down; only positions should move, not glyphs.
+    //
+    // 0..3 counter-clockwise quarter-turns, so Blue's quadrant walks
+    // top-left → bottom-left → bottom-right → top-right.
+    function ludoRotation() {
+        const P = (typeof userPreferences === 'object' && userPreferences) ? userPreferences : {};
+        const raw = P.ludoRotation;
+        const n = typeof raw === 'number' ? raw : parseInt(raw, 10);
+        return Number.isFinite(n) ? ((n % 4) + 4) % 4 : 0;
+    }
+
+    // (gr, gc) are grid-LINE coordinates in [0, LUDO_GRID] rather than cell
+    // indices, so this serves cell corners, cell centres (x.5), base slots and
+    // the board centre alike. The centre (7.5, 7.5) is a fixed point.
+    function ludoRotateGrid(gr, gc) {
+        const G = LUDO_GRID;
+        switch (ludoRotation()) {
+            case 1:  return { r: G - gc, c: gr };        // 90° CCW
+            case 2:  return { r: G - gr, c: G - gc };    // 180°
+            case 3:  return { r: gc,     c: G - gr };    // 90° CW
+            default: return { r: gr,     c: gc };
+        }
+    }
+
+    // Which HUD strip a colour's chip belongs in, derived from where its
+    // quadrant actually ended up rather than a fixed table — so the chips, the
+    // dice and the roll recap all follow the board round. A quarter-turn is a
+    // bijection on quadrants, so the four seats always land in four distinct
+    // (strip, side) slots and can never collide.
+    function ludoSeat(ci) {
+        const q = LUDO_COLORS[ci].quad;
+        const p = ludoRotateGrid((q.r0 + q.r1) / 2, (q.c0 + q.c1) / 2);
+        return {
+            strip: p.r < LUDO_GRID / 2 ? 'top'  : 'bottom',
+            side:  p.c < LUDO_GRID / 2 ? 'left' : 'right',
+        };
+    }
 
     // ── Interaction state ──────────────────────────────────────────────
     let ludoPhase      = 'idle';   // idle | awaitRoll | rolling | awaitMove | moving | over
@@ -46,10 +90,22 @@
     // ludoPointXY takes grid-line coords (base slots, triangle vertices);
     // ludoCellCenter takes a cell index and returns the middle of that cell.
     function ludoPointXY(r, c) {
-        return { x: LUDO_BOARD_X + c * LUDO_CELL, y: LUDO_BOARD_Y + r * LUDO_CELL };
+        const p = ludoRotateGrid(r, c);
+        return { x: LUDO_BOARD_X + p.c * LUDO_CELL, y: LUDO_BOARD_Y + p.r * LUDO_CELL };
     }
     function ludoCellCenter(r, c) {
         return ludoPointXY(r + 0.5, c + 0.5);
+    }
+
+    // Axis-aligned rect spanning grid lines [r0,r1] × [c0,c1]. A quarter-turn
+    // keeps a rect axis-aligned but moves which corner is which, so derive it
+    // from both rotated corners instead of assuming (r0,c0) is still top-left.
+    function ludoRectXY(r0, c0, r1, c1) {
+        const a = ludoPointXY(r0, c0), b = ludoPointXY(r1, c1);
+        return {
+            x: Math.min(a.x, b.x), y: Math.min(a.y, b.y),
+            w: Math.abs(b.x - a.x), h: Math.abs(b.y - a.y),
+        };
     }
 
     // Where token `i` of colour `ci` sits at an arbitrary step, including the
@@ -164,13 +220,13 @@
     }
 
     function ludoDrawCell(ctx, r, c, fill, stroke) {
-        const p = ludoPointXY(r, c);
+        const q = ludoRectXY(r, c, r + 1, c + 1);
         ctx.fillStyle = fill;
-        ctx.fillRect(p.x, p.y, LUDO_CELL, LUDO_CELL);
+        ctx.fillRect(q.x, q.y, q.w, q.h);
         if (stroke) {
             ctx.strokeStyle = stroke;
             ctx.lineWidth = 1;
-            ctx.strokeRect(p.x + 0.5, p.y + 0.5, LUDO_CELL - 1, LUDO_CELL - 1);
+            ctx.strokeRect(q.x + 0.5, q.y + 0.5, q.w - 1, q.h - 1);
         }
     }
 
@@ -194,13 +250,17 @@
         const col  = LUDO_COLORS[ci];
         const cur  = LUDO_RING[col.startIndex];
         const next = LUDO_RING[(col.startIndex + 1) % 52];
-        const dr = Math.sign(next.r - cur.r), dc = Math.sign(next.c - cur.c);
+        // Take the heading from the two squares' *drawn* positions, so the arrow
+        // turns with the board instead of always pointing the unrotated way.
+        // No start square sits on one of the four diagonal corner turns, so this
+        // is always exactly horizontal or vertical.
         const p  = ludoCellCenter(cur.r, cur.c);
+        const n  = ludoCellCenter(next.r, next.c);
         const L  = LUDO_CELL * 0.30;
 
         ctx.save();
         ctx.translate(p.x, p.y);
-        ctx.rotate(Math.atan2(dr, dc));
+        ctx.rotate(Math.atan2(n.y - p.y, n.x - p.x));
         ctx.beginPath();
         ctx.moveTo(L, 0);
         ctx.lineTo(-L * 0.65, -L * 0.8);
@@ -225,19 +285,18 @@
             const tint = on ? col.hex : ludoDim(col.hex);
             const deep = on ? col.deep : ludoDim(col.deep);
             const q = col.quad, b = col.basePanel;
-            const qp = ludoPointXY(q.r0, q.c0);
+            const qr = ludoRectXY(q.r0, q.c0, q.r1, q.c1);
 
             ctx.fillStyle = tint;
-            ctx.fillRect(qp.x, qp.y, (q.c1 - q.c0) * S, (q.r1 - q.r0) * S);
+            ctx.fillRect(qr.x, qr.y, qr.w, qr.h);
 
-            const bp = ludoPointXY(b.r0, b.c0);
-            const bw = (b.c1 - b.c0) * S, bh = (b.r1 - b.r0) * S;
+            const br = ludoRectXY(b.r0, b.c0, b.r1, b.c1);
             ctx.fillStyle = '#fbfcfe';
-            ludoRoundRect(ctx, bp.x, bp.y, bw, bh, 8);
+            ludoRoundRect(ctx, br.x, br.y, br.w, br.h, 8);
             ctx.fill();
             ctx.strokeStyle = deep;
             ctx.lineWidth = 2;
-            ludoRoundRect(ctx, bp.x + 1, bp.y + 1, bw - 2, bh - 2, 7);
+            ludoRoundRect(ctx, br.x + 1, br.y + 1, br.w - 2, br.h - 2, 7);
             ctx.stroke();
 
             col.baseSlots.forEach(s => {
@@ -291,7 +350,8 @@
         });
         ctx.strokeStyle = 'rgba(40,50,70,0.35)';
         ctx.lineWidth = 1.5;
-        ctx.strokeRect(ludoPointXY(6, 6).x, ludoPointXY(6, 6).y, S * 3, S * 3);
+        const cr = ludoRectXY(6, 6, 9, 9);
+        ctx.strokeRect(cr.x, cr.y, cr.w, cr.h);
 
         if (ludoDebugRing) {
             ctx.font = '8px monospace';
@@ -690,7 +750,7 @@
     function ludoDrawPool(ctx, strip) {
         if (!ludoStarted || ludoPhase === 'over' || !ludoPool.length) return;
         const cur  = ludoCurrentCi();
-        const seat = LUDO_SEATS[cur];
+        const seat = ludoSeat(cur);
         if (seat.strip !== strip) return;
 
         const D = 15, GAP = 2;
@@ -709,7 +769,7 @@
     // the moment the next roll starts (see ludoDoRoll).
     function ludoDrawRecap(ctx, strip) {
         if (!ludoRecap || !ludoRecap.faces.length) return;
-        const seat = LUDO_SEATS[ludoRecap.ci];
+        const seat = ludoSeat(ludoRecap.ci);
         if (seat.strip !== strip || !ludoIsActive(ludoRecap.ci)) return;
 
         // At most 4, most recent first-to-last. Three sixes is the natural
@@ -729,12 +789,12 @@
 
     function ludoDrawHud(ctx) {
         const cur = ludoCurrentCi();
-        const curStrip = ludoPhase === 'over' ? null : LUDO_SEATS[cur].strip;
+        const curStrip = ludoPhase === 'over' ? null : ludoSeat(cur).strip;
 
         ['top', 'bottom'].forEach(strip => {
             const y0 = strip === 'top' ? 0 : LUDO_CANVAS_H - LUDO_STRIP_H;
             ludoActive.forEach(ci => {
-                const seat = LUDO_SEATS[ci];
+                const seat = ludoSeat(ci);
                 if (seat.strip !== strip) return;
                 ludoDrawChip(ctx, ci, ludoChipX(seat.side),
                              y0 + (LUDO_STRIP_H - LUDO_CHIP_H) / 2,
@@ -1049,7 +1109,7 @@
 
     function ludoDiceHit(p) {
         if (ludoPhase === 'over') return false;
-        const seat = LUDO_SEATS[ludoCurrentCi()];
+        const seat = ludoSeat(ludoCurrentCi());
         const cy = seat.strip === 'top'
             ? LUDO_STRIP_H / 2
             : LUDO_CANVAS_H - LUDO_STRIP_H / 2;

--- a/ludo-dev/preview.js
+++ b/ludo-dev/preview.js
@@ -426,6 +426,18 @@ if (scenario === 'fresh') {
     L.place(0, 0, 12);
     L.recap = { ci: 0, faces: [6, 6, 6] };
     L.turn = 1;
+} else if (/^rot[0-3]$/.test(scenario)) {
+    // Same mid-game position at each quarter-turn, to eyeball that the board,
+    // the HUD chips and the dice all swing round together.
+    global.userPreferences.ludoRotation = parseInt(scenario.slice(3), 10);
+    L.ludoSetMode('cpu2');
+    L.startLudoGame();
+    L.place(0, 0, 8); L.place(0, 1, 24); L.place(0, 2, 52);
+    L.place(2, 0, 3); L.place(2, 1, 3); L.place(2, 2, 45);
+    load.forceDice(3);
+    L.ludoDoRoll();
+    pump(L.LUDO_DICE_MS + 40);
+    load.restoreDice();
 } else if (scenario === 'pool') {
     // 6,6,5 banked, one token out, popover open on it.
     L.ludoSetMode('cpu2');

--- a/ludo-dev/rotation-verify.js
+++ b/ludo-dev/rotation-verify.js
@@ -1,0 +1,320 @@
+// Board rotation: proves a quarter-turn moves pixels and nothing else.
+//
+// The whole safety argument for this feature is that rotation is presentational
+// — it must not be able to change a single legal move, a ring index or a token's
+// step. These assertions hold rotation to that, and separately check that what
+// *is* meant to move (quadrants, HUD chips, dice, hit-testing) all moves
+// together and stays on the board.
+const canvasStub = require('./canvas-stub');
+
+const RECT = { left: 0, top: 0, width: 344, height: 416 };
+const stub = {
+    width: 0, height: 0,
+    getContext: () => canvasStub(344, 416).ctx,
+    getBoundingClientRect: () => RECT,
+    addEventListener() {}, removeEventListener() {},
+};
+global.document = { getElementById: id => (id === 'ludo-canvas' ? stub : null) };
+global.requestAnimationFrame = () => 1;
+global.cancelAnimationFrame = () => {};
+const store = {};
+global.localStorage = {
+    getItem: k => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: k => { delete store[k]; },
+};
+global.awardGameXP = () => {};
+global.getFrameInterval = () => 0;
+
+const load = require('./load');
+const { forceDice, restoreDice } = load;
+
+let pass = 0, fail = 0;
+const ok = (name, cond, detail) => {
+    if (cond) { pass++; console.log(`  ✓ ${name}`); }
+    else      { fail++; console.log(`  ✗ ${name}${detail ? ' — ' + detail : ''}`); }
+};
+const head = t => console.log(`\n── ${t} ${'─'.repeat(Math.max(0, 46 - t.length))}`);
+
+const TURNS = [0, 1, 2, 3];
+const BLUE = 0, RED = 1, GREEN = 2, YELLOW = 3;
+const NAME = { 0: 'Blue', 1: 'Red', 2: 'Green', 3: 'Yellow' };
+
+function board(rot) {
+    const L = load({ ludoRotation: rot });
+    L.active = [0, 1, 2, 3];
+    L.ludoResetTokens();
+    L.turn = 0;
+    return L;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+head('Reading the preference');
+{
+    ok('missing pref means no rotation', load({}).ludoRotation() === 0);
+    TURNS.forEach(t => ok(`rotation ${t} reads back as ${t}`, load({ ludoRotation: t }).ludoRotation() === t));
+    ok('a numeric string is accepted', load({ ludoRotation: '2' }).ludoRotation() === 2);
+    ok('out of range wraps', load({ ludoRotation: 5 }).ludoRotation() === 1);
+    ok('negative wraps forward', load({ ludoRotation: -1 }).ludoRotation() === 3);
+    ok('garbage falls back to 0', load({ ludoRotation: 'sideways' }).ludoRotation() === 0);
+    ok('null falls back to 0', load({ ludoRotation: null }).ludoRotation() === 0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+head('Quadrants land where the setting promises');
+{
+    // The setting is labelled by where Blue ends up, so that had better be true.
+    const expect = ['top-left', 'bottom-left', 'bottom-right', 'top-right'];
+    TURNS.forEach(t => {
+        const L = board(t);
+        const s = L.ludoSeat(BLUE);
+        ok(`rotation ${t}: Blue is ${expect[t]}`,
+           s.strip + '-' + s.side === expect[t], `got ${s.strip}-${s.side}`);
+    });
+}
+{
+    // Turn order must stay clockwise on screen, or the board reads wrong.
+    TURNS.forEach(t => {
+        const L = board(t);
+        const corner = ci => {
+            const s = L.ludoSeat(ci);
+            return (s.strip === 'top' ? 0 : 2) + (s.side === 'left' ? 0 : 1);
+        };
+        // Clockwise from any corner: TL(0) → TR(1) → BR(3) → BL(2)
+        const cw = [0, 1, 3, 2];
+        const seats = [BLUE, RED, GREEN, YELLOW].map(corner);
+        const start = cw.indexOf(seats[0]);
+        const wanted = [0, 1, 2, 3].map(k => cw[(start + k) % 4]);
+        ok(`rotation ${t}: seats stay in clockwise order`,
+           seats.join() === wanted.join(), `${seats.join()} vs ${wanted.join()}`);
+    });
+}
+{
+    TURNS.forEach(t => {
+        const L = board(t);
+        const slots = [BLUE, RED, GREEN, YELLOW]
+            .map(ci => { const s = L.ludoSeat(ci); return s.strip + '-' + s.side; });
+        ok(`rotation ${t}: four seats occupy four distinct slots`,
+           new Set(slots).size === 4, slots.join(' '));
+    });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+head('Rotation is a rigid transform of the grid');
+{
+    TURNS.forEach(t => {
+        const L = board(t);
+        const seen = new Set();
+        let out = 0;
+        for (let r = 0; r < 15; r++) {
+            for (let c = 0; c < 15; c++) {
+                const p = L.ludoCellCenter(r, c);
+                seen.add(Math.round(p.x) + ':' + Math.round(p.y));
+                if (p.x < L.LUDO_BOARD_X || p.x > L.LUDO_BOARD_X + L.LUDO_BOARD ||
+                    p.y < L.LUDO_BOARD_Y || p.y > L.LUDO_BOARD_Y + L.LUDO_BOARD) out++;
+            }
+        }
+        ok(`rotation ${t}: all 225 cells map to distinct pixels`, seen.size === 225, 'got ' + seen.size);
+        ok(`rotation ${t}: no cell leaves the board`, out === 0, out + ' outside');
+    });
+}
+{
+    TURNS.forEach(t => {
+        const L = board(t);
+        const mid = L.ludoPointXY(7.5, 7.5);
+        ok(`rotation ${t}: the board centre is a fixed point`,
+           Math.abs(mid.x - (L.LUDO_BOARD_X + L.LUDO_BOARD / 2)) < 1e-9 &&
+           Math.abs(mid.y - (L.LUDO_BOARD_Y + L.LUDO_BOARD / 2)) < 1e-9);
+    });
+}
+{
+    const L = board(1);
+    const q = L.ludoRectXY(0, 0, 6, 6);
+    ok('a rotated rect stays axis-aligned and 6 cells square',
+       q.w === 6 * L.LUDO_CELL && q.h === 6 * L.LUDO_CELL, `${q.w}x${q.h}`);
+    ok('and starts on the board', q.x >= L.LUDO_BOARD_X && q.y >= L.LUDO_BOARD_Y);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+head('Every token position stays on the board');
+{
+    TURNS.forEach(t => {
+        const L = board(t);
+        let bad = 0, nonFinite = 0;
+        for (let ci = 0; ci < 4; ci++) {
+            for (let i = 0; i < 4; i++) {
+                for (let s = -1; s <= L.LUDO_HOME_STEP; s++) {
+                    const p = L.ludoPosForStep(ci, i, s);
+                    if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) { nonFinite++; continue; }
+                    if (p.x < L.LUDO_BOARD_X || p.x > L.LUDO_BOARD_X + L.LUDO_BOARD ||
+                        p.y < L.LUDO_BOARD_Y || p.y > L.LUDO_BOARD_Y + L.LUDO_BOARD) bad++;
+                }
+            }
+        }
+        ok(`rotation ${t}: every position finite`, nonFinite === 0, nonFinite + ' bad');
+        ok(`rotation ${t}: every position inside the board`, bad === 0, bad + ' outside');
+    });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+head('The model is untouched');
+{
+    // The point of the whole design: turning the board cannot change the rules.
+    const base = board(0);
+    const cells = [];
+    for (let ci = 0; ci < 4; ci++) {
+        for (let s = 0; s <= 55; s++) {
+            const c = base.ludoStepToCell(ci, s);
+            cells.push(ci + ':' + s + '=' + c.r + ',' + c.c + '/' + base.ludoStepToRing(ci, s));
+        }
+    }
+    TURNS.slice(1).forEach(t => {
+        const L = board(t);
+        const other = [];
+        for (let ci = 0; ci < 4; ci++) {
+            for (let s = 0; s <= 55; s++) {
+                const c = L.ludoStepToCell(ci, s);
+                other.push(ci + ':' + s + '=' + c.r + ',' + c.c + '/' + L.ludoStepToRing(ci, s));
+            }
+        }
+        ok(`rotation ${t}: step → cell and ring indices are identical`,
+           other.join('|') === cells.join('|'));
+    });
+}
+{
+    // Same board state, every rotation: the legal move set must not budge.
+    const setup = L => {
+        L.active = [BLUE, GREEN];
+        L.ludoResetTokens();
+        L.place(BLUE, 0, 12); L.place(BLUE, 1, 12); L.place(BLUE, 2, 40);
+        L.place(GREEN, 0, 3); L.place(GREEN, 1, 20); L.place(GREEN, 2, 54);
+    };
+    const sig = L => {
+        const out = [];
+        for (let ci of [BLUE, GREEN]) {
+            for (let roll = 1; roll <= 6; roll++) {
+                out.push(ci + ':' + roll + '=' + L.ludoLegalMoves(ci, roll)
+                    .map(m => m.token.i + '>' + m.to + (m.captures.length ? 'x' : ''))
+                    .sort().join(','));
+            }
+        }
+        return out.join('|');
+    };
+    const b = board(0); setup(b);
+    const want = sig(b);
+    TURNS.slice(1).forEach(t => {
+        const L = board(t); setup(L);
+        ok(`rotation ${t}: identical legal moves`, sig(L) === want);
+    });
+    const blocked = board(0); setup(blocked);
+    ok('the fixture actually produces moves', want.length > 40 && /\d>\d/.test(want));
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+head('Input follows the board round');
+{
+    TURNS.forEach(t => {
+        const L = board(t);
+        L.ludoSetMode('pvp2');
+        L.startLudoGame();
+        L.place(BLUE, 0, 10);
+        forceDice(4);
+        L.ludoDoRoll();
+        for (let e = 0; e < L.LUDO_DICE_MS + 40; e += 16) L.ludoUpdate(16);
+        restoreDice();
+
+        L.ludoRender();                                   // fills renderPos
+        const target = L.legal.filter(m => m.token.i === 0)[0];
+        const rp = target && L.renderPos.get(target.token);
+        ok(`rotation ${t}: the moving token has a drawn position`, !!rp);
+        if (!rp) return;
+
+        L.handleLudoPointerDown({ clientX: rp.x, clientY: rp.y, preventDefault() {} });
+        ok(`rotation ${t}: tapping it at its rotated position moves it`,
+           L.phase === 'moving' && L.hop.move.token === target.token, L.phase);
+    });
+}
+{
+    TURNS.forEach(t => {
+        const L = board(t);
+        L.ludoSetMode('pvp2');
+        L.startLudoGame();
+        const seat = L.ludoSeat(L.active[L.turn]);
+        const cy = seat.strip === 'top'
+            ? L.LUDO_STRIP_H / 2
+            : L.LUDO_CANVAS_H - L.LUDO_STRIP_H / 2;
+        ok(`rotation ${t}: the dice hit-box sits in the mover's strip`,
+           L.ludoDiceHit({ x: L.LUDO_CANVAS_W / 2, y: cy }));
+        const other = seat.strip === 'top'
+            ? L.LUDO_CANVAS_H - L.LUDO_STRIP_H / 2
+            : L.LUDO_STRIP_H / 2;
+        ok(`rotation ${t}: and not in the opposite strip`,
+           !L.ludoDiceHit({ x: L.LUDO_CANVAS_W / 2, y: other }));
+    });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+head('Rendering at every rotation');
+{
+    TURNS.forEach(t => {
+        const L = board(t);
+        let threw = null;
+        try {
+            ['cpu2', 'pvp2', 'pvp3', 'pvp4'].forEach(m => {
+                L.ludoSetMode(m);
+                L.ludoRender();
+                // Only seated colours have tokens — 2P modes have just two.
+                L.active.forEach(ci => {
+                    L.ludoResetTokens();
+                    for (let s = -1; s <= L.LUDO_HOME_STEP; s++) { L.place(ci, 0, s); L.ludoRender(); }
+                });
+            });
+        } catch (e) { threw = e.message; }
+        ok(`rotation ${t}: renders every mode and every step`, threw === null, threw);
+    });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+head('Turning the board mid-match');
+{
+    // Rotation is a display pref, so changing it during play must be harmless.
+    const L = load({ ludoRotation: 0 });
+    L.ludoSetMode('pvp2');
+    L.startLudoGame();
+    L.place(BLUE, 0, 17); L.place(BLUE, 1, 33);
+    L.place(GREEN, 0, 8);
+    forceDice(4);
+    L.ludoDoRoll();
+    for (let e = 0; e < L.LUDO_DICE_MS + 40; e += 16) L.ludoUpdate(16);
+    restoreDice();
+
+    const before = L.tokens.map(t => t.ci + ':' + t.i + ':' + t.step + ':' + t.inBase).join('|');
+    const legalBefore = L.legal.length;
+    const phaseBefore = L.phase;
+
+    global.userPreferences.ludoRotation = 2;              // turn it, mid-turn
+    L.ludoRender();
+
+    ok('tokens are untouched',
+       L.tokens.map(t => t.ci + ':' + t.i + ':' + t.step + ':' + t.inBase).join('|') === before);
+    ok('the pending move list is untouched', L.legal.length === legalBefore);
+    ok('the phase is untouched', L.phase === phaseBefore);
+    ok('the board draws in its new orientation', L.ludoRotation() === 2);
+
+    // And the match still finishes from here. Drive both seats rather than
+    // waiting on the 20s turn clock to time each one out — that converges far
+    // too slowly to bound with an iteration guard, and made this flaky.
+    let guard = 0;
+    while (L.phase !== 'over' && guard++ < 200000) {
+        L.ludoUpdate(16);
+        if (L.phase === 'awaitRoll') L.ludoDoRoll();
+        else if (L.phase === 'awaitMove' && L.legal.length) L.ludoPlayMove(L.legal[0]);
+    }
+    ok('the match still completes after turning', L.phase === 'over', 'guard=' + guard);
+    global.userPreferences.ludoRotation = 0;
+}
+
+console.log(`\n${'═'.repeat(50)}`);
+console.log(`  ${pass} passed, ${fail} failed`);
+console.log(`${'═'.repeat(50)}\n`);
+process.exit(fail ? 1 : 0);

--- a/ludo-dev/ui-verify.js
+++ b/ludo-dev/ui-verify.js
@@ -81,7 +81,7 @@ function rollSeq(L, faces) {
 }
 
 function diceCenter(L) {
-    const seat = L.LUDO_SEATS[L.active[L.turn]];
+    const seat = L.ludoSeat(L.active[L.turn]);
     return {
         x: L.LUDO_CANVAS_W / 2,
         y: seat.strip === 'top' ? L.LUDO_STRIP_H / 2 : L.LUDO_CANVAS_H - L.LUDO_STRIP_H / 2,

--- a/ludo-dev/verify-all.js
+++ b/ludo-dev/verify-all.js
@@ -8,6 +8,7 @@ const SUITES = [
     ['CPU',            'ai-verify.js'],
     ['Modes',          'modes-verify.js'],
     ['Interaction',    'ui-verify.js'],
+    ['Rotation',       'rotation-verify.js'],
     ['Render smoke',   'render-smoke.js'],
     // These two check the integration into AttendanceTimeCheckerPlus.js rather
     // than the engine, so they only mean anything once the block is inserted.


### PR DESCRIPTION
…st you

⚙️ > 🎲 Ludo Board turns the board in quarter-turns, labelled by where Blue lands: top-left (default), bottom-left, bottom-right, top-right. Stored as userPreferences.ludoRotation and applied live - it is a display pref, so changing it mid-match is safe and instant.

The design constraint was "don't break the game", so the whole feature rests on two rules, both asserted rather than assumed:

1. Rotate COORDINATES, not the model. ludoStepToCell, the ring indices and every rule still speak unrotated grid space, so a turn cannot change what is legal - only where it is painted. Everything already funnelled through ludoPointXY, so rotating inside that one function carried the board, tokens, ghosts, the hop animation and hit-testing with it for free.
2. Never rotate the canvas context. ctx.rotate would have been one line, but it drags the dice pips, chip labels and stack badges along and leaves them upside down. Only positions move; glyphs stay upright.

Two things were not automatic and needed handling:
- ludoDrawCell and the quadrant/base rects assumed (r0,c0) was still the top-left corner. A quarter-turn keeps a rect axis-aligned but moves which corner is which, so ludoRectXY derives it from both rotated corners.
- The HUD lives in strip space, not board space. ludoSeat(ci) now derives a colour's strip/side from its quadrant's rotated centre, replacing the static LUDO_SEATS table, so chips, the dice and the roll recap all follow the board round. A quarter-turn is a bijection on quadrants, so the four seats always land in four distinct slots - asserted, since a collision would stack two chips on top of each other.

New rotation-verify.js (76 assertions) holds rotation to the claim: legal-move sets and step->cell output are byte-identical across all four turns; all 225 cells stay distinct and on the board; the centre is a fixed point; seats never collide and stay clockwise; tapping a token at its rotated position still moves that token; the dice hit-box follows the mover's strip; and turning the board mid-turn leaves tokens, pending moves and phase untouched with the match still completing afterwards. host-smoke.js re-checks the headline claims against the integrated copy, including that a corrupt pref falls back to 0 instead of throwing.

Also fixed a latent flake: host-smoke and the rotation suite drove a hot-seat match by waiting for the 20s turn clock to time each turn out, which converges too slowly to bound with an iteration guard. Both now roll and play directly. The suite is stable over repeated runs.

600 assertions across 9 suites, all passing.