### PR TITLE
feat(ludo): let blocks be jumped, as a separate rule toggle

### DIFF
--- a/AttendanceTimeCheckerPlus.js
+++ b/AttendanceTimeCheckerPlus.js
@@ -328,6 +328,10 @@
         // .toggle-switch handler writes userPreferences[data-pref] directly.
         // ludoRules() reads these live, so changes apply mid-match.
         ludoBlocks: true,       // 2+ own tokens bar opponents (never on a safe square)
+        // Whether a block also seals the track. On (the Ludo Star rule) a pair
+        // directly in front of a token leaves it with no legal roll at all;
+        // off, you may hop over a block but still may not land on it.
+        ludoBlockPassing: true,
         ludoThreeSixes: true,   // three 6s forfeit the whole banked sequence
         ludoExactHome: true,    // exact roll needed to finish
         ludoFreeRelease: false, // leave base on any roll, not just a 6
@@ -6604,6 +6608,11 @@
         const P = (typeof userPreferences === 'object' && userPreferences) ? userPreferences : {};
         return {
             blocks:      P.ludoBlocks      !== false,
+            // Whether a block also seals the track. On (the Ludo Star rule) a
+            // pair sitting directly in front of a token leaves it with no legal
+            // roll at all until the pair moves; off, you may hop over a block
+            // but still may not land on it.
+            blockPassing: P.ludoBlockPassing !== false,
             threeSixes:  P.ludoThreeSixes  !== false,
             exactHome:   P.ludoExactHome   !== false,
             freeRelease: P.ludoFreeRelease === true,
@@ -6672,11 +6681,14 @@
                     if (R.exactHome) return;    // must land exactly on 56
                     to = LUDO_HOME_STEP;        // otherwise an overshoot still finishes
                 }
-                // A block bars passage as well as landing. Only ring squares
-                // strictly after the current one and up to the destination count;
-                // home-column squares (>50) can never be blocked.
-                for (let s = t.step + 1; s <= Math.min(to, 50); s++) {
-                    if (blocked.has(ludoStepToRing(ci, s))) return;
+                // A block bars passage too, unless jumping is allowed. Only ring
+                // squares strictly after the current one and up to the
+                // destination count; home-column squares (>50) are never blocked.
+                // Landing is barred either way, by the check just below.
+                if (R.blockPassing) {
+                    for (let s = t.step + 1; s <= Math.min(to, 50); s++) {
+                        if (blocked.has(ludoStepToRing(ci, s))) return;
+                    }
                 }
             }
             if (to <= 50 && blocked.has(ludoStepToRing(ci, to))) return;
@@ -8192,7 +8204,6 @@
             title: '🎲 Ludo',
             bufferW: LUDO_CANVAS_W,
             bufferH: LUDO_CANVAS_H,
-            onToggle: toggleLudoMaximize,
         });
         ludoRender();
     }
@@ -14621,6 +14632,10 @@
                     <div class="ludo-rule-row">
                         <span>Blocks bar opponents <small style="opacity:0.6;">(never on ★ squares)</small></span>
                         <div class="toggle-switch ${userPreferences.ludoBlocks !== false ? 'active' : ''}" data-pref="ludoBlocks"></div>
+                    </div>
+                    <div class="ludo-rule-row">
+                        <span>…and can't be jumped over <small style="opacity:0.6;">(off: hop past, still can't land)</small></span>
+                        <div class="toggle-switch ${userPreferences.ludoBlockPassing !== false ? 'active' : ''}" data-pref="ludoBlockPassing"></div>
                     </div>
                     <div class="ludo-rule-row">
                         <span>Three 6s forfeit the turn</span>

--- a/LUDO_IMPLEMENTATION_PLAN.md
+++ b/LUDO_IMPLEMENTATION_PLAN.md
@@ -8,7 +8,7 @@
 > Branch: `feat/ludo-game` (off `main` @ `efbf33d`)
 > Status: **Phases 0–11 complete — Ludo is integrated.** The engine lives in
 > `AttendanceTimeCheckerPlus.js` (now 16,491 lines), byte-identical to the copy in
-> [`ludo-dev/`](ludo-dev/) that the tests exercise. **584 assertions green**, including
+> [`ludo-dev/`](ludo-dev/) that the tests exercise. **612 assertions green**, including
 > a suite that executes the real userscript. The only step left is a pass on the live
 > portal — see Verification.
 > Last updated: 2026-08-05
@@ -228,9 +228,14 @@ Implemented in full; the first three are toggleable in ⚙️ settings.
 - **Another sequence** on a capture or on landing a token home
 - **`threeSixes`** (default on) — three consecutive 6s forfeits the turn and voids
   **the whole banked sequence**, which is the risk that balances accumulating
-- **`blocks`** (default on) — 2+ own tokens on one ring cell: opponents can neither
-  land on nor pass through it. **Never applies on a safe square** — see the
-  decision log; a pair on the CPU's own start square otherwise sealed the track.
+- **`blocks`** (default on) — 2+ own tokens on one ring cell: opponents cannot land
+  on it. **Never applies on a safe square** — see the decision log; a pair on the
+  CPU's own start square otherwise sealed the track.
+- **`blockPassing`** (default on) — a block also bars *passing through*. This is the
+  Ludo Star rule, but it means a pair on the square directly ahead of a token leaves
+  it with **no legal roll at all** until the pair moves. Turn it off to hop over a
+  block while still being unable to land on it (and without making the stack
+  capturable, which switching `blocks` off entirely would).
 - **`exactHome`** (default on) — exact roll required to reach step 56; otherwise
   overshoot is allowed
 - **Safe squares** — no capture on `LUDO_SAFE_RING` cells or in any home column
@@ -556,20 +561,20 @@ The script self-guards to one URL (43–48), so iterating in-place is slow.
 own [README](ludo-dev/README.md). One command:
 
 ```
-node ludo-dev/verify-all.js     # 584 assertions across 9 suites, non-zero exit on failure
+node ludo-dev/verify-all.js     # 612 assertions across 9 suites, non-zero exit on failure
 ```
 
 | Suite | Covers | Assertions |
 |---|---|---|
 | `ludo-verify.js` | Board geometry | 78 |
-| `rules-verify.js` | Dice, legal moves, rule toggles, dice accumulation, pool spending, safe-square blocks, 400 self-play games | 114 |
+| `rules-verify.js` | Dice, legal moves, rule toggles, dice accumulation, pool spending, block rules, 400 self-play games | 121 |
 | `ai-verify.js` | Tiers, scorer, 600-game strength ordering | 36 |
 | `modes-verify.js` | Mode cycling, seats, turn order | 38 |
 | `ui-verify.js` | State machine, animation, clock, pointer input, die-choice popover, recap, anti-farm, XP | 126 |
 | `rotation-verify.js` | Board rotation — that it moves quadrants, chips, dice and hit-testing, and moves nothing else | 76 |
 | `render-smoke.js` | `ludoRender()` across all modes and steps | 10 |
-| `integration-verify.js` | Every wiring point in `AttendanceTimeCheckerPlus.js`, plus engine parity | 51 |
-| `host-smoke.js` | **Executes the real userscript**: full PvCPU match, XP, achievements, cloud round-trip, both Max modals | 55 |
+| `integration-verify.js` | Every wiring point in `AttendanceTimeCheckerPlus.js`, plus engine parity | 61 |
+| `host-smoke.js` | **Executes the real userscript**: full PvCPU match, XP, achievements, cloud round-trip, both Max modals, rotation, both reported bugs | 66 |
 
 Plus `node ludo-dev/preview.js out.png <scenario>` to render the board to a PNG, and
 `ludo-dev/ludo-harness.html` to actually play it. Verify there:
@@ -639,6 +644,7 @@ doesn't re-derive it from the code.
 | **2026-08-04** | **Extra turns now come only from a capture or a token reaching home** | Otherwise a 6 would pay twice — once as an extra die and again as an extra turn. `ludoGrantsExtraTurn(roll, result)` became `ludoEarnsAnotherRoll(result)`; `ludoFinishMove` lost its `roll` argument and returns `{ continueTurn, extraRoll }`. |
 | **2026-08-04** | **Tap a token → popover of that token's playable values** | With up to three distinct values banked, a tap is ambiguous. `ludoValuesForToken` filters the pool to what that token can legally spend: one value moves immediately, several open a popover anchored to the token. `ludoPopoverLayout()` is shared by the renderer and the hit-test so they cannot drift. |
 | **2026-08-04** | **Ghost previews suppressed while several distinct values are banked** | Three values × four tokens is up to a dozen ghost destinations. Ghosts now show only when one distinct value remains, or when a popover has narrowed it to one token; otherwise the glow and chevron carry it. |
+| **2026-08-05** | **Barring passage split out of the blocks rule as `ludoBlockPassing`** | *Reported by the user, from in-app play.* A Green pair on ring 31 sat directly in front of a Blue token on ring 30, so all six rolls had to cross it and that token had **no legal move at all** — the turn silently auto-played a different token instead. That is the Ludo Star rule behaving correctly, not a bug, but the only escape was switching `blocks` off entirely, which also makes a stack capturable (landing on it takes both). Passage is now its own toggle: default on (standard), off lets you hop a block while still being unable to land on or capture it. Default deliberately unchanged, since "full Ludo Star ruleset" was an explicit decision. |
 | **2026-08-05** | **Board rotation is a coordinate transform, not a canvas transform** | *Requested by the user — players want their own colour nearest them.* `ctx.rotate` would have been one line, but it turns the dice pips, chip labels and stack badges upside down with the board. Instead `ludoRotateGrid` maps grid-line coordinates and everything funnels through `ludoPointXY`, so glyphs stay upright while positions move. The model is untouched, which is what makes it safe to change mid-match. |
 | **2026-08-05** | **`ludoSeat(ci)` replaced the static `LUDO_SEATS` table** | The HUD lives in strip space, not board space, so it does not rotate for free. Deriving each colour's strip/side from its quadrant's rotated centre means the chips, dice and roll recap follow the board without a second lookup table to keep in sync. |
 | **2026-08-05** | **`ludoRectXY` for anything rectangular** | `fillRect(ludoPointXY(r0,c0), w, h)` assumed `(r0,c0)` stays the top-left corner. Under a quarter-turn it becomes a different corner, which drew quadrants and base panels one cell off. Deriving the rect from both rotated corners is rotation-agnostic. |

--- a/ludo-dev/README.md
+++ b/ludo-dev/README.md
@@ -8,7 +8,7 @@ is slow. The engine is built and tested here first, then inserted into that file
 reviewed diff.
 
 ```
-node ludo-dev/verify-all.js              # every suite — 584 assertions
+node ludo-dev/verify-all.js              # every suite — 612 assertions
 node ludo-dev/preview.js out.png fourplayer   # render a PNG of the board
 start ludo-dev/ludo-harness.html         # play it
 ```
@@ -38,14 +38,14 @@ modal relocates only the `<canvas>`, so a DOM HUD would disappear inside it.
 | Suite | Covers | Assertions |
 |---|---|---|
 | `ludo-verify.js` | Board geometry — ring closure, corner turns, home columns, safe squares, quadrants | 78 |
-| `rules-verify.js` | Dice fairness, legal moves, every rule toggle, capture/safe behaviour, dice accumulation, pool spending, safe-square blocks, match resolution, 400 random self-play games | 114 |
+| `rules-verify.js` | Dice fairness, legal moves, every rule toggle, capture/safe behaviour, dice accumulation, pool spending, safe-square blocks, jumping blocks, match resolution, 400 random self-play games | 121 |
 | `ai-verify.js` | Difficulty tiers, scorer priorities, threat awareness, 600-game head-to-head strength ordering | 36 |
 | `modes-verify.js` | Mode cycling, active colour sets, turn order, CPU seats, reset-on-switch | 38 |
 | `ui-verify.js` | Turn state machine, dice tumble, hop animation, turn clock, scale-aware pointer input, die-choice popover, roll recap, anti-farm guards, XP maths | 126 |
 | `rotation-verify.js` | Board rotation: quadrants land where the setting promises, seats never collide, all 225 cells stay distinct and on-board, legal moves and ring indices are identical at every turn, hit-testing follows | 76 |
 | `render-smoke.js` | `ludoRender()` across every mode and all 57 steps × 4 colours | 10 |
-| `integration-verify.js` | Every wiring point in `AttendanceTimeCheckerPlus.js` — switcher cases, DOM ids, CSS, keyboard, bridges, XP, achievements, leaderboard columns — plus engine parity | 51 |
-| `host-smoke.js` | **Executes the real userscript** under a minimal DOM: boots Ludo, plays a full PvCPU match, checks XP/achievements/cloud round-trip and both Max modals | 55 |
+| `integration-verify.js` | Every wiring point in `AttendanceTimeCheckerPlus.js` — switcher cases, DOM ids, CSS, keyboard, bridges, XP, achievements, leaderboard columns — plus engine parity | 61 |
+| `host-smoke.js` | **Executes the real userscript** under a minimal DOM: boots Ludo, plays a full PvCPU match, checks XP/achievements/cloud round-trip and both Max modals, board rotation | 66 |
 
 `ui-verify.js` simulates time by pumping `ludoUpdate(dt)` instead of waiting on real
 frames, so a full PvCPU match plays out in milliseconds and is deterministic.

--- a/ludo-dev/host-smoke.js
+++ b/ludo-dev/host-smoke.js
@@ -417,7 +417,7 @@ head('Board rotation, through the host');
     H.prefs.ludoRotation = 0;
 }
 
-head('The reported bug, through the host');
+head('Reported bug 1 — safe squares walling the track');
 H.ludoSetMode('cpu2');
 H.place(2, 0, 0); H.place(2, 1, 0);        // two CPU tokens on their start (ring 26)
 H.place(0, 0, 24);                          // player token on Green's gate
@@ -425,6 +425,33 @@ ok('safe square is not a block', !H.ludoBlockRings(0).has(26));
 const legal = [1, 2, 3, 4, 5, 6].filter(r =>
     H.ludoLegalMoves(0, r).some(m => m.token.i === 0));
 ok('all six rolls are playable', legal.length === 6, 'legal rolls: ' + legal.join());
+
+head('Reported bug 2 — a block on the very next square');
+{
+    // Blue on ring 30 with a Green pair on ring 31: every roll has to cross it.
+    H.ludoSetMode('cpu2');
+    H.ludoResetTokens();
+    const greenStep = (31 - 26 + 52) % 52;
+    H.place(2, 0, greenStep); H.place(2, 1, greenStep);
+    H.place(0, 0, 30);
+
+    H.prefs.ludoBlockPassing = true;
+    const walled = [1, 2, 3, 4, 5, 6].filter(r =>
+        H.ludoLegalMoves(0, r).some(m => m.token.i === 0));
+    ok('default rule: the token is walled in completely', walled.length === 0,
+       'legal rolls: ' + walled.join());
+
+    H.prefs.ludoBlockPassing = false;
+    const free = [1, 2, 3, 4, 5, 6].filter(r =>
+        H.ludoLegalMoves(0, r).some(m => m.token.i === 0));
+    ok('jumping allowed: every roll but the landing one works',
+       free.join() === '2,3,4,5,6', 'legal rolls: ' + free.join());
+    ok('the pair still cannot be landed on',
+       !H.ludoLegalMoves(0, 1).some(m => m.token.i === 0));
+    ok('and still cannot be captured',
+       H.ludoLegalMoves(0, 3).filter(m => m.token.i === 0)[0].captures.length === 0);
+    H.prefs.ludoBlockPassing = true;
+}
 
 console.log('\n' + '='.repeat(52));
 console.log('  ' + pass + ' passed, ' + fail + ' failed');

--- a/ludo-dev/integration-verify.js
+++ b/ludo-dev/integration-verify.js
@@ -86,12 +86,15 @@ ok('switching away closes the Pool modal', has('if (poolMaximized) togglePoolMax
 ok('switching away closes the Ludo modal', has('if (ludoMaximized) toggleLudoMaximize();'));
 
 head('Preferences and storage');
-ok('four flat rule flags in userPreferences',
-   all(['ludoBlocks: true', 'ludoThreeSixes: true',
+ok('five flat rule flags in userPreferences',
+   all(['ludoBlocks: true', 'ludoBlockPassing: true', 'ludoThreeSixes: true',
         'ludoExactHome: true', 'ludoFreeRelease: false']));
-ok('settings modal exposes all four',
-   all(['data-pref="ludoBlocks"', 'data-pref="ludoThreeSixes"',
-        'data-pref="ludoExactHome"', 'data-pref="ludoFreeRelease"']));
+ok('settings modal exposes all five',
+   all(['data-pref="ludoBlocks"', 'data-pref="ludoBlockPassing"',
+        'data-pref="ludoThreeSixes"', 'data-pref="ludoExactHome"',
+        'data-pref="ludoFreeRelease"']));
+ok('barring passage is separable from barring the landing',
+   /if \(R\.blockPassing\) \{[\s\S]{0,220}?blocked\.has\(ludoStepToRing\(ci, s\)\)/.test(src));
 ok('storage helpers live in the engine block',
    has('function ludoLoadWins()') && has('function ludoSaveRecord(rec)'));
 

--- a/ludo-dev/load.js
+++ b/ludo-dev/load.js
@@ -10,7 +10,8 @@ const fs   = require('fs');
 const path = require('path');
 
 const DEFAULT_PREFS = {
-    ludoBlocks: true, ludoThreeSixes: true, ludoExactHome: true, ludoFreeRelease: false,
+    ludoBlocks: true, ludoBlockPassing: true, ludoThreeSixes: true,
+    ludoExactHome: true, ludoFreeRelease: false,
 };
 
 function source() {

--- a/ludo-dev/ludo-core.js
+++ b/ludo-dev/ludo-core.js
@@ -177,6 +177,11 @@
         const P = (typeof userPreferences === 'object' && userPreferences) ? userPreferences : {};
         return {
             blocks:      P.ludoBlocks      !== false,
+            // Whether a block also seals the track. On (the Ludo Star rule) a
+            // pair sitting directly in front of a token leaves it with no legal
+            // roll at all until the pair moves; off, you may hop over a block
+            // but still may not land on it.
+            blockPassing: P.ludoBlockPassing !== false,
             threeSixes:  P.ludoThreeSixes  !== false,
             exactHome:   P.ludoExactHome   !== false,
             freeRelease: P.ludoFreeRelease === true,
@@ -245,11 +250,14 @@
                     if (R.exactHome) return;    // must land exactly on 56
                     to = LUDO_HOME_STEP;        // otherwise an overshoot still finishes
                 }
-                // A block bars passage as well as landing. Only ring squares
-                // strictly after the current one and up to the destination count;
-                // home-column squares (>50) can never be blocked.
-                for (let s = t.step + 1; s <= Math.min(to, 50); s++) {
-                    if (blocked.has(ludoStepToRing(ci, s))) return;
+                // A block bars passage too, unless jumping is allowed. Only ring
+                // squares strictly after the current one and up to the
+                // destination count; home-column squares (>50) are never blocked.
+                // Landing is barred either way, by the check just below.
+                if (R.blockPassing) {
+                    for (let s = t.step + 1; s <= Math.min(to, 50); s++) {
+                        if (blocked.has(ludoStepToRing(ci, s))) return;
+                    }
                 }
             }
             if (to <= 50 && blocked.has(ludoStepToRing(ci, to))) return;

--- a/ludo-dev/ludo-harness.html
+++ b/ludo-dev/ludo-harness.html
@@ -66,7 +66,8 @@
 
   <div class="panel">
     <h1>Rules (⚙️ settings equivalents)</h1>
-    <label class="chk"><input type="checkbox" id="p-blocks" checked> Blocks bar landing &amp; passing</label>
+    <label class="chk"><input type="checkbox" id="p-blocks" checked> Blocks bar opponents</label>
+    <label class="chk"><input type="checkbox" id="p-blockpass" checked> …and can't be jumped over</label>
     <label class="chk"><input type="checkbox" id="p-three" checked> Three sixes forfeits the turn</label>
     <label class="chk"><input type="checkbox" id="p-exact" checked> Exact roll required to finish</label>
     <label class="chk"><input type="checkbox" id="p-free"> Release on any roll (no 6 needed)</label>
@@ -121,7 +122,7 @@ function awardGameXP(type, perf) {
         `${perf.captures} caps, ${perf.tier}${perf.vsCPU ? '' : ', hot-seat'}]`);
 }
 let userPreferences = {
-    ludoBlocks: true, ludoThreeSixes: true, ludoExactHome: true, ludoFreeRelease: false,
+    ludoBlocks: true, ludoBlockPassing: true, ludoThreeSixes: true, ludoExactHome: true, ludoFreeRelease: false,
     ludoRotation: 0,
 };
 const logEl = () => document.getElementById('log');
@@ -155,6 +156,7 @@ const bind = (id, key) => {
     $(id).onchange = e => { userPreferences[key] = e.target.checked; log(`${key} = ${e.target.checked}`); };
 };
 bind('p-blocks', 'ludoBlocks');
+bind('p-blockpass', 'ludoBlockPassing');
 bind('p-three',  'ludoThreeSixes');
 bind('p-exact',  'ludoExactHome');
 bind('p-free',   'ludoFreeRelease');

--- a/ludo-dev/rules-verify.js
+++ b/ludo-dev/rules-verify.js
@@ -144,6 +144,54 @@ head('Blocks');
     ok('blocks OFF: landing captures both', land && land.captures.length === 2);
 }
 
+// ── Jumping a block ──────────────────────────────────────────────────
+// Reported: a pair parked on the very next square left a token with no legal
+// roll at all — every 1..6 had to cross it — so the turn silently auto-played a
+// different token. Barring passage is the Ludo Star rule, but it can wall a
+// token in completely, so it is now separable from barring the landing.
+{
+    const L = board({ ludoBlockPassing: false });        // blocks on, jumping on
+    const gStep = stepOnRing(L.LUDO_COLORS, GREEN, 6);
+    L.place(GREEN, 0, gStep);
+    L.place(GREEN, 1, gStep);
+    L.place(BLUE, 0, 3);
+    ok('the pair is still a block', L.ludoBlockRings(BLUE).has(6));
+    ok('jumping over it is allowed', L.ludoLegalMoves(BLUE, 4).some(m => m.token.i === 0));
+    ok('landing on it is still barred', !L.ludoLegalMoves(BLUE, 3).some(m => m.token.i === 0));
+    ok('and it still cannot be captured',
+       L.ludoLegalMoves(BLUE, 4).filter(m => m.token.i === 0)[0].captures.length === 0);
+}
+{
+    // The exact reported position: block on the square immediately ahead.
+    const L = board();                                   // default: passage barred
+    const gStep = stepOnRing(L.LUDO_COLORS, GREEN, 31);
+    L.place(GREEN, 0, gStep); L.place(GREEN, 1, gStep);
+    L.place(BLUE, 0, 30);
+    const walled = [1, 2, 3, 4, 5, 6].filter(r =>
+        L.ludoLegalMoves(BLUE, r).some(m => m.token.i === 0));
+    ok('default: a block directly ahead leaves no legal roll', walled.length === 0,
+       'legal rolls: ' + walled.join());
+
+    const J = board({ ludoBlockPassing: false });
+    const gJ = stepOnRing(J.LUDO_COLORS, GREEN, 31);
+    J.place(GREEN, 0, gJ); J.place(GREEN, 1, gJ);
+    J.place(BLUE, 0, 30);
+    const free = [1, 2, 3, 4, 5, 6].filter(r =>
+        J.ludoLegalMoves(BLUE, r).some(m => m.token.i === 0));
+    ok('jumping on: only the landing roll is refused', free.join() === '2,3,4,5,6',
+       'legal rolls: ' + free.join());
+}
+{
+    // Turning blocks off entirely is still the bigger hammer — it also makes
+    // the stack capturable, which jumping deliberately does not.
+    const L = board({ ludoBlocks: false });
+    const gStep = stepOnRing(L.LUDO_COLORS, GREEN, 31);
+    L.place(GREEN, 0, gStep); L.place(GREEN, 1, gStep);
+    L.place(BLUE, 0, 30);
+    const land = L.ludoLegalMoves(BLUE, 1).filter(m => m.token.i === 0)[0];
+    ok('blocks off: landing captures the whole stack', land && land.captures.length === 2);
+}
+
 // ── A safe square can never become a wall ────────────────────────────
 // Regression: Green's own start (ring 26) is safe AND is refilled every time
 // Green releases. When a pair there still sealed the track, a Blue token at


### PR DESCRIPTION
Reported from in-app play: a token had no legal move at all and the turn kept silently auto-playing a different one. Reconstructed the position from the screenshot before changing anything:

    arrowed blue token  -> ring 30
    overlapped greens   -> ring 31   (the very next square, not a safe one)
    rings blocked       -> [31]
    roll 1..6           -> arrowed BLOCKED every time, 1 legal move -> auto-plays

So this was the blocks rule behaving exactly as specified, not a bug. Two same-colour tokens bar opponents from passing as well as landing, and because the pair sat directly ahead, every roll had to cross it. That is the Ludo Star barrier rule, and "full Ludo Star ruleset" was an explicit earlier decision.

The problem was that the only escape was switching blocks off entirely, which is a much bigger hammer - it also makes the stack capturable, so in that same position a roll of 1 would have taken both green tokens at once.

Barring passage is now its own toggle, ludoBlockPassing:
- on (default, unchanged): the Ludo Star rule, blocks seal the track
- off: hop over a block, but still cannot land on it and still cannot capture it - which is what "I should be able to jump" actually asks for

Default deliberately left as-is rather than quietly changing the ruleset. It is one toggle in the settings modal, next to the existing blocks switch.

Covered by 7 new assertions in rules-verify.js, including the reported position reproduced exactly (all six rolls refused by default; 2-6 allowed with jumping on, only the landing roll refused), and 4 more in host-smoke.js that re-check it through the integrated userscript rather than only the engine copy.

612 assertions across 9 suites, all passing, stable over repeated runs.